### PR TITLE
Solves the straggler initialization problem, and moves iterator increment.

### DIFF
--- a/fjmi.py
+++ b/fjmi.py
@@ -190,7 +190,7 @@ def merge_insertion_sort (A):
     hasStraggler = len(A) % 2 != 0
 
     if hasStraggler:
-        straggler = a.pop(len(A) -1)
+        straggler = A.pop(len(A) -1)
     else:
         straggler = False
 

--- a/fjmi.py
+++ b/fjmi.py
@@ -147,6 +147,9 @@ def create_s(sorted_split_array, straggler, print_comparision_estimation):
           item = pend[iterator - 1]
           indexSequence.append(iterator)
           last = "not-jacob"
+          # Increment our iterators
+          iterator += 1
+          jacobindex += 1
 
       # we now have the most optimal item to insert (with the least comparisons!).
       # lets use bisect to get the insertion point
@@ -154,9 +157,6 @@ def create_s(sorted_split_array, straggler, print_comparision_estimation):
 
       # then insert it into S!
       S.insert(insertion_point, item)
-      # Increment our iterators
-      iterator += 1
-      jacobindex += 1
 
       # Update comparisions counter
       comparisions_made += 2


### PR DESCRIPTION
Hi,
I had some problems when I tested the algorithms, especially with lists of more than 46 numbers. While debugging, I could see that the algorithm was skipping a number, since the iterator was constantly incrementing when entering the `if` to use the Jacob sequence.
```
Starting Array:
[11, 34, 28, 32, 29, 39, 42, 6, 30, 46, 45, 41, 1, 23, 15, 44, 9, 22, 18, 33, 27, 35, 20, 17, 24, 43, 5, 14, 16, 2, 19, 12, 7, 4, 3, 40, 37, 26, 38, 13, 25, 8, 31, 21, 36, 10]
Sorted Array:
[2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46]
```
Number 1 is missing.

Also a small bug when initializing the straggler.
I never code in python, if there is something I am missing, let me know! ^u^